### PR TITLE
fix(eslint): next/server error when next is not in the root

### DIFF
--- a/packages/eslint-plugin-next/lib/rules/no-server-import-in-page.js
+++ b/packages/eslint-plugin-next/lib/rules/no-server-import-in-page.js
@@ -3,7 +3,7 @@ const path = require('path')
 module.exports = {
   meta: {
     docs: {
-      description: 'Disallow importing next/server outside of middleware.js',
+      description: 'Disallow importing next/server outside of middleware',
       recommended: true,
       url: 'https://nextjs.org/docs/messages/no-server-import-in-page',
     },
@@ -16,17 +16,13 @@ module.exports = {
         }
 
         const filename = context.getFilename()
-        if (
-          filename.startsWith('middleware.') ||
-          filename.startsWith(`${path.sep}middleware.`) ||
-          filename.startsWith(`${path.posix.sep}middleware.`)
-        ) {
+        if (filename.match(/(?:^|\/)middleware\.(?:t|j)s$/)) {
           return
         }
 
         context.report({
           node,
-          message: `next/server should not be imported outside of middleware.js. See: https://nextjs.org/docs/messages/no-server-import-in-page`,
+          message: `next/server should not be imported outside of Middleware. Read more: https://nextjs.org/docs/messages/no-server-import-in-page`,
         })
       },
     }

--- a/test/integration/rewrites-client-rerender/next.config.js
+++ b/test/integration/rewrites-client-rerender/next.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  rewrites() {
+    return [
+      {
+        source: '/rewrite',
+        destination: '/?foo=bar',
+      },
+    ]
+  },
+}

--- a/test/integration/rewrites-client-rerender/pages/index.js
+++ b/test/integration/rewrites-client-rerender/pages/index.js
@@ -1,0 +1,13 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+
+export default function Index() {
+  const { query } = useRouter()
+
+  useEffect(() => {
+    window.__renders = window.__renders || []
+    window.__renders.push(query.foo)
+  })
+
+  return <p>A page should not be rerendered if unnecessary.</p>
+}

--- a/test/integration/rewrites-client-rerender/test/index.test.js
+++ b/test/integration/rewrites-client-rerender/test/index.test.js
@@ -1,0 +1,55 @@
+/* eslint-env jest */
+
+import { join } from 'path'
+import {
+  findPort,
+  killApp,
+  launchApp,
+  nextBuild,
+  nextStart,
+} from 'next-test-utils'
+import webdriver from 'next-webdriver'
+
+const appDir = join(__dirname, '../')
+
+let appPort
+let app
+
+const runTests = () => {
+  it('should not trigger unncessary rerenders', async () => {
+    const browser = await webdriver(appPort, '/')
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    expect(await browser.eval('window.__renders')).toEqual([undefined])
+  })
+
+  it('should rerender with the correct query parameter if present', async () => {
+    const browser = await webdriver(appPort, '/rewrite')
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    expect(await browser.eval('window.__renders')).toEqual([undefined, 'bar'])
+  })
+}
+
+describe('rewrites client rerender', () => {
+  describe('dev mode', () => {
+    beforeAll(async () => {
+      appPort = await findPort()
+      app = await launchApp(appDir, appPort)
+    })
+    afterAll(() => killApp(app))
+
+    runTests()
+  })
+
+  describe('production mode', () => {
+    beforeAll(async () => {
+      await nextBuild(appDir)
+      appPort = await findPort()
+      app = await nextStart(appDir, appPort)
+    })
+    afterAll(() => killApp(app))
+
+    runTests()
+  })
+})

--- a/test/unit/eslint-plugin-next/no-server-import-in-page.test.ts
+++ b/test/unit/eslint-plugin-next/no-server-import-in-page.test.ts
@@ -13,6 +13,14 @@ import rule from '@next/eslint-plugin-next/lib/rules/no-server-import-in-page'
 })
 const ruleTester = new RuleTester()
 
+const errors = [
+  {
+    message:
+      'next/server should not be imported outside of Middleware. Read more: https://nextjs.org/docs/messages/no-server-import-in-page',
+    type: 'ImportDeclaration',
+  },
+]
+
 ruleTester.run('no-server-import-in-page', rule, {
   valid: [
     {
@@ -34,6 +42,15 @@ ruleTester.run('no-server-import-in-page', rule, {
       filename: `${path.sep}middleware.js`,
     },
     {
+      code: `import { NextFetchEvent, NextRequest } from "next/server"
+
+      export function middleware(req, ev) {
+        return new Response('Hello, world!')
+      }
+    `,
+      filename: `middleware.ts`,
+    },
+    {
       code: `import NextDocument from "next/document"
 
       export function middleware(req, ev) {
@@ -49,7 +66,7 @@ ruleTester.run('no-server-import-in-page', rule, {
         return new Response('Hello, world!')
       }
     `,
-      filename: 'middleware.page.tsx',
+      filename: path.join('ws', 'vercel-front/front/middleware.ts'),
     },
   ],
   invalid: [
@@ -59,13 +76,7 @@ ruleTester.run('no-server-import-in-page', rule, {
       export const Test = () => <p>Test</p>
       `,
       filename: 'components/test.js',
-      errors: [
-        {
-          message:
-            'next/server should not be imported outside of middleware.js. See: https://nextjs.org/docs/messages/no-server-import-in-page',
-          type: 'ImportDeclaration',
-        },
-      ],
+      errors,
     },
     {
       code: `import { NextFetchEvent, NextRequest } from "next/server"
@@ -73,13 +84,7 @@ ruleTester.run('no-server-import-in-page', rule, {
       export const Test = () => <p>Test</p>
       `,
       filename: 'pages/test.js',
-      errors: [
-        {
-          message:
-            'next/server should not be imported outside of middleware.js. See: https://nextjs.org/docs/messages/no-server-import-in-page',
-          type: 'ImportDeclaration',
-        },
-      ],
+      errors,
     },
     {
       code: `import { NextFetchEvent, NextRequest } from "next/server"
@@ -87,13 +92,17 @@ ruleTester.run('no-server-import-in-page', rule, {
       export const Test = () => <p>Test</p>
       `,
       filename: `pages${path.sep}test.js`,
-      errors: [
-        {
-          message:
-            'next/server should not be imported outside of middleware.js. See: https://nextjs.org/docs/messages/no-server-import-in-page',
-          type: 'ImportDeclaration',
-        },
-      ],
+      errors,
+    },
+    {
+      code: `import { NextFetchEvent, NextRequest } from "next/server"
+
+      export function middleware(req, ev) {
+        return new Response('Hello, world!')
+      }
+    `,
+      filename: 'middleware.page.tsx',
+      errors,
     },
   ],
 })


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
