### PR TITLE
feat: enables 'edge' as a possible runtime for API routes, prevents rendering pages on stable edge runtime

### DIFF
--- a/docs/advanced-features/react-18/switchable-runtime.md
+++ b/docs/advanced-features/react-18/switchable-runtime.md
@@ -63,7 +63,7 @@ For example, for API routes that rely on native Node.js APIs, they need to run w
 
 ```typescript
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default (req) => new Response('Hello world!')

--- a/docs/api-reference/edge-runtime.md
+++ b/docs/api-reference/edge-runtime.md
@@ -144,7 +144,7 @@ You can relax the check to allow specific files with your Middleware or Edge API
 
 ```javascript
 export const config = {
-  runtime: 'experimental-edge', // for Edge API Routes only
+  runtime: 'edge', // for Edge API Routes only
   unstable_allowDynamic: [
     '/lib/utilities.js', // allows a single file
     '/node_modules/function-bind/**', // use a glob to allow anything in the function-bind 3rd party module

--- a/docs/api-routes/edge-api-routes.md
+++ b/docs/api-routes/edge-api-routes.md
@@ -14,7 +14,7 @@ Any file inside the folder `pages/api` is mapped to `/api/*` and will be treated
 
 ```typescript
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default (req) => new Response('Hello world!')
@@ -26,7 +26,7 @@ export default (req) => new Response('Hello world!')
 import type { NextRequest } from 'next/server'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function handler(req: NextRequest) {
@@ -50,7 +50,7 @@ export default async function handler(req: NextRequest) {
 import type { NextRequest } from 'next/server'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function handler(req: NextRequest) {
@@ -75,7 +75,7 @@ export default async function handler(req: NextRequest) {
 import type { NextRequest } from 'next/server'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function handler(req: NextRequest) {
@@ -91,7 +91,7 @@ export default async function handler(req: NextRequest) {
 import { type NextRequest } from 'next/server'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function handler(req: NextRequest) {

--- a/errors/edge-dynamic-code-evaluation.md
+++ b/errors/edge-dynamic-code-evaluation.md
@@ -33,7 +33,7 @@ You can relax the check to allow specific files with your Middleware or Edge API
 
 ```typescript
 export const config = {
-  runtime: 'experimental-edge', // for Edge API Routes only
+  runtime: 'edge', // for Edge API Routes only
   unstable_allowDynamic: [
     '/lib/utilities.js', // allows a single file
     '/node_modules/function-bind/**', // use a glob to allow anything in the function-bind 3rd party module

--- a/errors/middleware-upgrade-guide.md
+++ b/errors/middleware-upgrade-guide.md
@@ -175,7 +175,7 @@ If you were previously using Middleware to forward headers to an external API, y
 import { type NextRequest } from 'next/server'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function handler(req: NextRequest) {

--- a/examples/with-webassembly/pages/api/edge.ts
+++ b/examples/with-webassembly/pages/api/edge.ts
@@ -13,4 +13,4 @@ export default async function handler() {
   return new Response(`got: ${number}`)
 }
 
-export const config = { runtime: 'experimental-edge' }
+export const config = { runtime: 'edge' }

--- a/packages/next/build/analysis/extract-const-value.ts
+++ b/packages/next/build/analysis/extract-const-value.ts
@@ -204,7 +204,7 @@ function extractValue(node: Node, path?: string[]): any {
 
 /**
  * Extracts the value of an exported const variable named `exportedName`
- * (e.g. "export const config = { runtime: 'experimental-edge' }") from swc's AST.
+ * (e.g. "export const config = { runtime: 'edge' }") from swc's AST.
  * The value must be one of (or throws UnsupportedValueError):
  *   - string
  *   - boolean

--- a/packages/next/build/analysis/get-page-static-info.ts
+++ b/packages/next/build/analysis/get-page-static-info.ts
@@ -1,18 +1,20 @@
-import { isServerRuntime } from '../../server/config-shared'
 import type { NextConfig } from '../../server/config-shared'
 import type { Middleware, RouteHas } from '../../lib/load-custom-routes'
+
+import { promises as fs } from 'fs'
+import { matcher } from 'next/dist/compiled/micromatch'
+import { ServerRuntime } from 'next/types'
 import {
   extractExportedConstValue,
   UnsupportedValueError,
 } from './extract-const-value'
 import { parseModule } from './parse-module'
-import { promises as fs } from 'fs'
-import { tryToParsePath } from '../../lib/try-to-parse-path'
 import * as Log from '../output/log'
 import { SERVER_RUNTIME } from '../../lib/constants'
-import { ServerRuntime } from 'next/types'
 import { checkCustomRoutes } from '../../lib/load-custom-routes'
-import { matcher } from 'next/dist/compiled/micromatch'
+import { tryToParsePath } from '../../lib/try-to-parse-path'
+import { isAPIRoute } from '../../lib/is-api-route'
+import { isEdgeRuntime } from '../../lib/is-edge-runtime'
 import { RSC_MODULE_TYPES } from '../../shared/lib/constants'
 
 export interface MiddlewareConfig {
@@ -229,13 +231,13 @@ function getMiddlewareConfig(
   return result
 }
 
-let warnedAboutExperimentalEdgeApiFunctions = false
-function warnAboutExperimentalEdgeApiFunctions() {
-  if (warnedAboutExperimentalEdgeApiFunctions) {
+let warnedAboutExperimentalEdge = false
+function warnAboutExperimentalEdge() {
+  if (warnedAboutExperimentalEdge) {
     return
   }
   Log.warn(`You are using an experimental edge runtime, the API might change.`)
-  warnedAboutExperimentalEdgeApiFunctions = true
+  warnedAboutExperimentalEdge = true
 }
 
 const warnedUnsupportedValueMap = new Map<string, boolean>()
@@ -307,7 +309,8 @@ export async function getPageStaticInfo(params: {
 
     if (
       typeof resolvedRuntime !== 'undefined' &&
-      !isServerRuntime(resolvedRuntime)
+      (resolvedRuntime === SERVER_RUNTIME.nodejs ||
+        isEdgeRuntime(resolvedRuntime))
     ) {
       const options = Object.values(SERVER_RUNTIME).join(', ')
       if (typeof resolvedRuntime !== 'string') {
@@ -326,15 +329,28 @@ export async function getPageStaticInfo(params: {
 
     const requiresServerRuntime = ssr || ssg || pageType === 'app'
 
-    resolvedRuntime =
-      SERVER_RUNTIME.edge === resolvedRuntime
-        ? SERVER_RUNTIME.edge
-        : requiresServerRuntime
-        ? resolvedRuntime || nextConfig.experimental?.runtime
-        : undefined
+    resolvedRuntime = isEdgeRuntime(resolvedRuntime)
+      ? resolvedRuntime
+      : requiresServerRuntime
+      ? resolvedRuntime || nextConfig.experimental?.runtime
+      : undefined
 
-    if (resolvedRuntime === SERVER_RUNTIME.edge) {
-      warnAboutExperimentalEdgeApiFunctions()
+    if (resolvedRuntime === SERVER_RUNTIME.experimentalEdge) {
+      warnAboutExperimentalEdge()
+    }
+
+    if (
+      resolvedRuntime === SERVER_RUNTIME.edge &&
+      pageType === 'pages' &&
+      page &&
+      !isAPIRoute(page)
+    ) {
+      Log.error(
+        `Page ${page} provided runtime 'edge', the edge runtime for rendering is currently experimental. Use runtime 'experimental-edge' instead.`
+      )
+      if (!isDev) {
+        process.exit(1)
+      }
     }
 
     const middlewareConfig = getMiddlewareConfig(

--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -12,13 +12,13 @@ import chalk from 'next/dist/compiled/chalk'
 import { posix, join } from 'path'
 import { stringify } from 'querystring'
 import {
-  API_ROUTE,
   PAGES_DIR_ALIAS,
   ROOT_DIR_ALIAS,
   APP_DIR_ALIAS,
-  SERVER_RUNTIME,
   WEBPACK_LAYERS,
 } from '../lib/constants'
+import { isAPIRoute } from '../lib/is-api-route'
+import { isEdgeRuntime } from '../lib/is-edge-runtime'
 import { APP_CLIENT_INTERNALS, RSC_MODULE_TYPES } from '../shared/lib/constants'
 import {
   CLIENT_STATIC_FILES_RUNTIME_AMP,
@@ -175,7 +175,7 @@ export function getEdgeServerEntry(opts: {
     return `next-middleware-loader?${stringify(loaderParams)}!`
   }
 
-  if (opts.page.startsWith('/api/') || opts.page === '/api') {
+  if (isAPIRoute(opts.page)) {
     const loaderParams: EdgeFunctionLoaderOptions = {
       absolutePagePath: opts.absolutePagePath,
       page: opts.page,
@@ -257,8 +257,8 @@ export async function runDependingOnPageType<T>(params: {
     await params.onEdgeServer()
     return
   }
-  if (params.page.match(API_ROUTE)) {
-    if (params.pageRuntime === SERVER_RUNTIME.edge) {
+  if (isAPIRoute(params.page)) {
+    if (isEdgeRuntime(params.pageRuntime)) {
       await params.onEdgeServer()
       return
     }
@@ -279,7 +279,7 @@ export async function runDependingOnPageType<T>(params: {
     await Promise.all([params.onClient(), params.onServer()])
     return
   }
-  if (params.pageRuntime === SERVER_RUNTIME.edge) {
+  if (isEdgeRuntime(params.pageRuntime)) {
     await Promise.all([params.onClient(), params.onEdgeServer()])
     return
   }

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -18,7 +18,6 @@ import {
   PUBLIC_DIR_MIDDLEWARE_CONFLICT,
   MIDDLEWARE_FILENAME,
   PAGES_DIR_ALIAS,
-  SERVER_RUNTIME,
 } from '../lib/constants'
 import { fileExists } from '../lib/file-exists'
 import { findPagesDir } from '../lib/find-pages-dir'
@@ -109,6 +108,7 @@ import { writeBuildId } from './write-build-id'
 import { normalizeLocalePath } from '../shared/lib/i18n/normalize-locale-path'
 import { NextConfigComplete } from '../server/config-shared'
 import isError, { NextError } from '../lib/is-error'
+import { isEdgeRuntime } from '../lib/is-edge-runtime'
 import { TelemetryPlugin } from './webpack/plugins/telemetry-plugin'
 import { MiddlewareManifest } from './webpack/plugins/middleware-plugin'
 import { recursiveCopy } from '../lib/recursive-copy'
@@ -1427,7 +1427,7 @@ export default async function build(
                   try {
                     let edgeInfo: any
 
-                    if (pageRuntime === SERVER_RUNTIME.edge) {
+                    if (isEdgeRuntime(pageRuntime)) {
                       if (pageType === 'app') {
                         edgeRuntimeAppCount++
                       } else {
@@ -1466,7 +1466,7 @@ export default async function build(
                     if (pageType === 'app' && originalAppPath) {
                       appNormalizedPaths.set(originalAppPath, page)
                       // TODO-APP: handle prerendering with edge
-                      if (pageRuntime === 'experimental-edge') {
+                      if (isEdgeRuntime(pageRuntime)) {
                         isStatic = false
                         isSsg = false
                       } else {
@@ -1504,7 +1504,7 @@ export default async function build(
                         )
                       }
                     } else {
-                      if (pageRuntime === SERVER_RUNTIME.edge) {
+                      if (isEdgeRuntime(pageRuntime)) {
                         if (workerResult.hasStaticProps) {
                           console.warn(
                             `"getStaticProps" is not yet supported fully with "experimental-edge", detected on ${page}`

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -20,7 +20,6 @@ import {
   SERVER_PROPS_GET_INIT_PROPS_CONFLICT,
   SERVER_PROPS_SSG_CONFLICT,
   MIDDLEWARE_FILENAME,
-  SERVER_RUNTIME,
 } from '../lib/constants'
 import { MODERN_BROWSERSLIST_TARGET } from '../shared/lib/constants'
 import prettyBytes from '../lib/pretty-bytes'
@@ -33,6 +32,7 @@ import { GetStaticPaths, PageConfig, ServerRuntime } from 'next/types'
 import { BuildManifest } from '../server/get-page-files'
 import { removeTrailingSlash } from '../shared/lib/router/utils/remove-trailing-slash'
 import { UnwrapPromise } from '../lib/coalesced-function'
+import { isEdgeRuntime } from '../lib/is-edge-runtime'
 import { normalizeLocalePath } from '../shared/lib/i18n/normalize-locale-path'
 import * as Log from './output/log'
 import {
@@ -423,7 +423,7 @@ export async function printTreeView(
           ? '○'
           : pageInfo?.isSsg
           ? '●'
-          : pageInfo?.runtime === SERVER_RUNTIME.edge
+          : isEdgeRuntime(pageInfo?.runtime)
           ? 'ℇ'
           : 'λ'
 
@@ -1267,7 +1267,7 @@ export async function isPageStatic({
       let prerenderFallback: boolean | 'blocking' | undefined
       let appConfig: AppConfig = {}
 
-      if (pageRuntime === SERVER_RUNTIME.edge) {
+      if (isEdgeRuntime(pageRuntime)) {
         const runtime = await getRuntimeContext({
           paths: edgeInfo.files.map((file: string) => path.join(distDir, file)),
           env: edgeInfo.env,

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -10,13 +10,13 @@ import {
   PAGES_DIR_ALIAS,
   ROOT_DIR_ALIAS,
   APP_DIR_ALIAS,
-  SERVER_RUNTIME,
   WEBPACK_LAYERS,
   RSC_MOD_REF_PROXY_ALIAS,
 } from '../lib/constants'
 import { EXTERNAL_PACKAGES } from '../lib/server-external-packages'
 import { fileExists } from '../lib/file-exists'
 import { CustomRoutes } from '../lib/load-custom-routes.js'
+import { isEdgeRuntime } from '../lib/is-edge-runtime'
 import {
   CLIENT_STATIC_FILES_RUNTIME_AMP,
   CLIENT_STATIC_FILES_RUNTIME_MAIN,
@@ -628,7 +628,7 @@ export default async function getBaseWebpackConfig(
   const disableOptimizedLoading = true
 
   if (isClient) {
-    if (config.experimental.runtime === SERVER_RUNTIME.edge) {
+    if (isEdgeRuntime(config.experimental.runtime)) {
       Log.warn(
         'You are using the experimental Edge Runtime with `experimental.runtime`.'
       )

--- a/packages/next/build/webpack/loaders/next-edge-ssr-loader/render.ts
+++ b/packages/next/build/webpack/loaders/next-edge-ssr-loader/render.ts
@@ -72,7 +72,7 @@ export function getRender({
       pagesType,
       extendRenderOpts: {
         buildId,
-        runtime: SERVER_RUNTIME.edge,
+        runtime: SERVER_RUNTIME.experimentalEdge,
         supportsDynamicHTML: true,
         disableOptimizedLoading: true,
         serverComponentManifest,

--- a/packages/next/build/webpack/loaders/next-serverless-loader/index.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/index.ts
@@ -2,7 +2,7 @@ import devalue from 'next/dist/compiled/devalue'
 import { join } from 'path'
 import { parse } from 'querystring'
 import { webpack } from 'next/dist/compiled/webpack/webpack'
-import { API_ROUTE } from '../../../../lib/constants'
+import { isAPIRoute } from '../../../../lib/is-api-route'
 import { isDynamicRoute } from '../../../../shared/lib/router/utils'
 import { escapeStringRegexp } from '../../../../shared/lib/escape-regexp'
 import { __ApiPreviewProps } from '../../../../server/api-utils'
@@ -88,7 +88,7 @@ const nextServerlessLoader: webpack.LoaderDefinitionFunction = function () {
       `
     : 'const runtimeConfig = {}'
 
-  if (page.match(API_ROUTE)) {
+  if (isAPIRoute(page)) {
     return `
         ${envLoading}
         ${runtimeConfigImports}

--- a/packages/next/build/webpack/plugins/flight-types-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-types-plugin.ts
@@ -58,7 +58,11 @@ interface IEntry {
   dynamicParams?: boolean
   fetchCache?: 'auto' | 'force-no-store' | 'only-no-store' | 'default-no-store' | 'default-cache' | 'only-cache' | 'force-cache'
   preferredRegion?: 'auto' | 'home' | 'edge'
-  ${options.type === 'page' ? "runtime?: 'nodejs' | 'experimental-edge'" : ''}
+  ${
+    options.type === 'page'
+      ? "runtime?: 'nodejs' | 'experimental-edge' | 'edge'"
+      : ''
+  }
 }
 
 // =============

--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -13,7 +13,7 @@ import { promisify } from 'util'
 import { AmpPageStatus, formatAmpMessages } from '../build/output/index'
 import * as Log from '../build/output/log'
 import createSpinner from '../build/spinner'
-import { API_ROUTE, SSG_FALLBACK_EXPORT_ERROR } from '../lib/constants'
+import { SSG_FALLBACK_EXPORT_ERROR } from '../lib/constants'
 import { recursiveCopy } from '../lib/recursive-copy'
 import { recursiveDelete } from '../lib/recursive-delete'
 import {
@@ -40,6 +40,7 @@ import { denormalizePagePath } from '../shared/lib/page-path/denormalize-page-pa
 import { loadEnvConfig } from '@next/env'
 import { PrerenderManifest } from '../build'
 import { PagesManifest } from '../build/webpack/plugins/pages-manifest-plugin'
+import { isAPIRoute } from '../lib/is-api-route'
 import { getPagePath } from '../server/require'
 import { Span } from '../trace'
 import { FontConfig } from '../server/font-utils'
@@ -243,7 +244,7 @@ export default async function exportApp(
       // _error is exported as 404.html later on
       // API Routes are Node.js functions
 
-      if (page.match(API_ROUTE)) {
+      if (isAPIRoute(page)) {
         hasApiRoutes = true
         continue
       }
@@ -475,7 +476,7 @@ export default async function exportApp(
 
     const filteredPaths = exportPaths.filter(
       // Remove API routes
-      (route) => !exportPathMap[route].page.match(API_ROUTE)
+      (route) => !isAPIRoute(exportPathMap[route].page)
     )
 
     if (filteredPaths.length !== exportPaths.length) {

--- a/packages/next/lib/constants.ts
+++ b/packages/next/lib/constants.ts
@@ -1,8 +1,5 @@
 import type { ServerRuntime } from '../types'
 
-// Regex for API routes
-export const API_ROUTE = /^\/api(?:\/|$)/
-
 // Patterns to detect middleware files
 export const MIDDLEWARE_FILENAME = 'middleware'
 export const MIDDLEWARE_LOCATION_REGEXP = `(?:src/)?${MIDDLEWARE_FILENAME}`
@@ -65,7 +62,8 @@ export const ESLINT_PROMPT_VALUES = [
 ]
 
 export const SERVER_RUNTIME: Record<string, ServerRuntime> = {
-  edge: 'experimental-edge',
+  edge: 'edge',
+  experimentalEdge: 'experimental-edge',
   nodejs: 'nodejs',
 }
 

--- a/packages/next/lib/is-api-route.ts
+++ b/packages/next/lib/is-api-route.ts
@@ -1,0 +1,3 @@
+export function isAPIRoute(value?: string) {
+  return Boolean(value === '/api' || value?.startsWith('/api/'))
+}

--- a/packages/next/lib/is-edge-runtime.ts
+++ b/packages/next/lib/is-edge-runtime.ts
@@ -1,0 +1,8 @@
+import { ServerRuntime } from '../types'
+import { SERVER_RUNTIME } from './constants'
+
+export function isEdgeRuntime(value?: string): value is ServerRuntime {
+  return (
+    value === SERVER_RUNTIME.experimentalEdge || value === SERVER_RUNTIME.edge
+  )
+}

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -33,6 +33,7 @@ import type { FontLoaderManifest } from '../build/webpack/plugins/font-loader-ma
 import { parse as parseQs } from 'querystring'
 import { format as formatUrl, parse as parseUrl } from 'url'
 import { getRedirectStatus } from '../lib/redirect-status'
+import { isEdgeRuntime } from '../lib/is-edge-runtime'
 import {
   NEXT_BUILTIN_DOCUMENT,
   STATIC_STATUS_PAGES,
@@ -1080,7 +1081,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         }
         // strip header so we generate HTML still
         if (
-          opts.runtime !== 'experimental-edge' ||
+          !isEdgeRuntime(opts.runtime) ||
           (this.serverOptions as any).webServerConfig
         ) {
           for (const param of FLIGHT_PARAMETERS) {
@@ -1293,7 +1294,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     })
     if (
       this.nextConfig.experimental.fetchCache &&
-      (opts.runtime !== 'experimental-edge' ||
+      (!isEdgeRuntime(opts.runtime) ||
         (this.serverOptions as any).webServerConfig)
     ) {
       delete req.headers[FETCH_CACHE_HEADER]

--- a/packages/next/server/config-schema.ts
+++ b/packages/next/server/config-schema.ts
@@ -1,6 +1,7 @@
 import { NextConfig } from './config'
 import type { JSONSchemaType } from 'ajv'
 import { VALID_LOADERS } from '../shared/lib/image-config'
+import { SERVER_RUNTIME } from '../lib/constants'
 
 const configSchema = {
   type: 'object',
@@ -353,7 +354,7 @@ const configSchema = {
         },
         runtime: {
           // automatic typing doesn't like enum
-          enum: ['experimental-edge', 'nodejs'] as any,
+          enum: Object.values(SERVER_RUNTIME) as any,
           type: 'string',
         },
         serverComponentsExternalPackages: {

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -623,12 +623,6 @@ export async function normalizeConfig(phase: string, config: any) {
   return await config
 }
 
-export function isServerRuntime(value?: string): value is ServerRuntime {
-  return (
-    value === undefined || value === 'nodejs' || value === 'experimental-edge'
-  )
-}
-
 export function validateConfig(userConfig: NextConfig): {
   errors?: Array<any> | null
 } {

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -31,6 +31,7 @@ import fs from 'fs'
 import { join, relative, resolve, sep } from 'path'
 import { IncomingMessage, ServerResponse } from 'http'
 import { addRequestMeta, getRequestMeta } from './request-meta'
+import { isAPIRoute } from '../lib/is-api-route'
 import { isDynamicRoute } from '../shared/lib/router/utils'
 import {
   PAGES_MANIFEST,
@@ -1199,7 +1200,7 @@ export default class NextNodeServer extends BaseServer {
         }
         const bubbleNoFallback = !!query._nextBubbleNoFallback
 
-        if (pathname === '/api' || pathname.startsWith('/api/')) {
+        if (isAPIRoute(pathname)) {
           delete query._nextBubbleNoFallback
 
           const handled = await this.handleApiRequest(req, res, pathname, query)
@@ -1268,7 +1269,7 @@ export default class NextNodeServer extends BaseServer {
     if (!pageFound && this.dynamicRoutes) {
       for (const dynamicRoute of this.dynamicRoutes) {
         params = dynamicRoute.match(pathname) || undefined
-        if (dynamicRoute.page.startsWith('/api') && params) {
+        if (isAPIRoute(dynamicRoute.page) && params) {
           page = dynamicRoute.page
           pageFound = true
           break

--- a/packages/next/server/next-typescript.ts
+++ b/packages/next/server/next-typescript.ts
@@ -132,6 +132,7 @@ const API_DOCS: Record<
       'The `runtime` option controls the preferred runtime to render this route.',
     options: {
       '"nodejs"': 'Prefer the Node.js runtime.',
+      '"edge"': 'Prefer the Edge runtime.',
       '"experimental-edge"': 'Prefer the experimental Edge runtime.',
     },
     link: 'https://beta.nextjs.org/docs/api-reference/segment-config#runtime',

--- a/packages/next/server/router.ts
+++ b/packages/next/server/router.ts
@@ -12,6 +12,7 @@ import {
   getNextInternalQuery,
   NextUrlWithParsedQuery,
 } from './request-meta'
+import { isAPIRoute } from '../lib/is-api-route'
 import { getPathMatch } from '../shared/lib/router/utils/path-match'
 import { removeTrailingSlash } from '../shared/lib/router/utils/remove-trailing-slash'
 import { normalizeLocalePath } from '../shared/lib/i18n/normalize-locale-path'
@@ -374,7 +375,7 @@ export default class Router {
         if (
           pathnameInfo.locale &&
           !route.matchesLocaleAPIRoutes &&
-          pathnameInfo.pathname.match(/^\/api(?:\/|$)/)
+          isAPIRoute(pathnameInfo.pathname)
         ) {
           continue
         }

--- a/packages/next/server/web-server.ts
+++ b/packages/next/server/web-server.ts
@@ -5,17 +5,17 @@ import type { NextParsedUrlQuery, NextUrlWithParsedQuery } from './request-meta'
 import type { Params } from '../shared/lib/router/utils/route-matcher'
 import type { PayloadOptions } from './send-payload'
 import type { LoadComponentsReturnType } from './load-components'
-import { NoFallbackError, Options } from './base-server'
 import type { DynamicRoutes, PageChecker, Route } from './router'
 import type { NextConfig } from './config-shared'
 import type { BaseNextRequest, BaseNextResponse } from './base-http'
 import type { UrlWithParsedQuery } from 'url'
 
-import BaseServer from './base-server'
 import { byteLength } from './api-utils/web'
+import BaseServer, { NoFallbackError, Options } from './base-server'
 import { generateETag } from './lib/etag'
 import { addRequestMeta } from './request-meta'
 import WebResponseCache from './response-cache/web'
+import { isAPIRoute } from '../lib/is-api-route'
 import { getPathMatch } from '../shared/lib/router/utils/path-match'
 import getRouteFromAssetPath from '../shared/lib/router/utils/get-route-from-asset-path'
 import { detectDomainLocale } from '../shared/lib/i18n/detect-domain-locale'
@@ -307,7 +307,7 @@ export default class NextWebServer extends BaseServer<WebServerOptions> {
         }
         const bubbleNoFallback = !!query._nextBubbleNoFallback
 
-        if (pathname === '/api' || pathname.startsWith('/api/')) {
+        if (isAPIRoute(pathname)) {
           delete query._nextBubbleNoFallback
         }
 

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -44,6 +44,7 @@ import { removeLocale } from '../../../client/remove-locale'
 import { removeBasePath } from '../../../client/remove-base-path'
 import { addBasePath } from '../../../client/add-base-path'
 import { hasBasePath } from '../../../client/has-base-path'
+import { isAPIRoute } from '../../../lib/is-api-route'
 import { getNextPathnameInfo } from './utils/get-next-pathname-info'
 import { formatNextPathnameInfo } from './utils/format-next-pathname-info'
 import { compareRouterStates } from './utils/compare-states'
@@ -2061,7 +2062,7 @@ export default class Router implements BaseRouter {
         }
       }
 
-      if (route === '/api' || route.startsWith('/api/')) {
+      if (isAPIRoute(route)) {
         handleHardNavigation({ url: as, router: this })
         return new Promise<never>(() => {})
       }

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -23,7 +23,7 @@ import {
 // @ts-ignore This path is generated at build time and conflicts otherwise
 import next from '../dist/server/next'
 
-export type ServerRuntime = 'nodejs' | 'experimental-edge' | undefined
+export type ServerRuntime = 'nodejs' | 'experimental-edge' | 'edge' | undefined
 
 // @ts-ignore This path is generated at build time and conflicts otherwise
 export { NextConfig } from '../dist/server/config'

--- a/test/e2e/app-dir/app-middleware/pages/api/dump-headers-edge.js
+++ b/test/e2e/app-dir/app-middleware/pages/api/dump-headers-edge.js
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default (req) => {

--- a/test/e2e/app-dir/app/pages/api/hello.js
+++ b/test/e2e/app-dir/app/pages/api/hello.js
@@ -3,5 +3,5 @@ export default function api(req) {
 }
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }

--- a/test/e2e/edge-api-endpoints-can-receive-body/app/pages/api/edge.js
+++ b/test/e2e/edge-api-endpoints-can-receive-body/app/pages/api/edge.js
@@ -7,5 +7,5 @@ export default async (req) => {
 }
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }

--- a/test/e2e/edge-api-endpoints-can-receive-body/app/pages/api/index.js
+++ b/test/e2e/edge-api-endpoints-can-receive-body/app/pages/api/index.js
@@ -7,5 +7,5 @@ export default async (req) => {
 }
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }

--- a/test/e2e/edge-async-local-storage/index.test.ts
+++ b/test/e2e/edge-async-local-storage/index.test.ts
@@ -10,7 +10,7 @@ describe('edge api can use async local storage', () => {
     {
       title: 'a single instance',
       code: `
-        export const config = { runtime: 'experimental-edge' }
+        export const config = { runtime: 'edge' }
         const storage = new AsyncLocalStorage()
   
         export default async function handler(request) {
@@ -36,7 +36,7 @@ describe('edge api can use async local storage', () => {
     {
       title: 'multiple instances',
       code: `
-        export const config = { runtime: 'experimental-edge' }
+        export const config = { runtime: 'edge' }
         const topStorage = new AsyncLocalStorage()
   
         export default async function handler(request) {

--- a/test/e2e/edge-can-use-wasm-files/index.test.ts
+++ b/test/e2e/edge-can-use-wasm-files/index.test.ts
@@ -49,7 +49,7 @@ describe('edge api endpoints can use wasm files', () => {
             const value = await increment(input);
             return new Response(null, { headers: { data: JSON.stringify({ input, value }) } });
           }
-          export const config = { runtime: 'experimental-edge' };
+          export const config = { runtime: 'edge' };
         `,
         'src/add.wasm': new FileRef(path.join(__dirname, './add.wasm')),
         'src/add.js': `

--- a/test/e2e/edge-compiler-can-import-blob-assets/app/pages/api/edge.js
+++ b/test/e2e/edge-compiler-can-import-blob-assets/app/pages/api/edge.js
@@ -1,4 +1,4 @@
-export const config = { runtime: 'experimental-edge' }
+export const config = { runtime: 'edge' }
 
 /**
  * @param {import('next/server').NextRequest} req

--- a/test/e2e/middleware-general/app/pages/api/edge-search-params.js
+++ b/test/e2e/middleware-general/app/pages/api/edge-search-params.js
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 
-export const config = { runtime: 'experimental-edge', regions: 'default' }
+export const config = { runtime: 'edge', regions: 'default' }
 
 /**
  * @param {import('next/server').NextRequest}

--- a/test/e2e/middleware-request-header-overrides/app/pages/api/dump-headers-edge.js
+++ b/test/e2e/middleware-request-header-overrides/app/pages/api/dump-headers-edge.js
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default (req) => {

--- a/test/e2e/og-api/app/pages/api/og.js
+++ b/test/e2e/og-api/app/pages/api/og.js
@@ -2,7 +2,7 @@
 import { ImageResponse } from '@vercel/og'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default function () {

--- a/test/e2e/skip-trailing-slash-redirect/app/pages/api/test-cookie-edge.js
+++ b/test/e2e/skip-trailing-slash-redirect/app/pages/api/test-cookie-edge.js
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default function handler(req) {

--- a/test/e2e/streaming-ssr/streaming-ssr/pages/api/user/[id].js
+++ b/test/e2e/streaming-ssr/streaming-ssr/pages/api/user/[id].js
@@ -3,5 +3,5 @@ export default async function handler() {
 }
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -45,15 +45,10 @@ describe('Switchable runtime', () => {
 
   beforeAll(async () => {
     next = await createNext({
-      files: {
-        app: new FileRef(join(__dirname, './app')),
-        pages: new FileRef(join(__dirname, './pages')),
-        utils: new FileRef(join(__dirname, './utils')),
-        'next.config.js': new FileRef(join(__dirname, './next.config.js')),
-      },
+      files: new FileRef(__dirname),
       dependencies: {
-        react: 'experimental',
-        'react-dom': 'experimental',
+        react: 'latest',
+        'react-dom': 'latest',
       },
     })
     context = {
@@ -229,7 +224,7 @@ describe('Switchable runtime', () => {
           'pages/api/switch-in-dev.js',
           `
           export const config = {
-            runtime: 'experimental-edge',
+            runtime: 'edge',
           }
 
           export default () => new Response('edge response')
@@ -259,7 +254,7 @@ describe('Switchable runtime', () => {
           'pages/api/switch-in-dev.js',
           `
           export const config = {
-            runtime: 'experimental-edge',
+            runtime: 'edge',
           }
 
           export default () => new Response('edge response again')
@@ -340,7 +335,7 @@ describe('Switchable runtime', () => {
           'pages/api/switch-in-dev-same-content.js',
           `
           export const config = {
-            runtime: 'experimental-edge',
+            runtime: 'edge',
           }
 
           export default () => new Response('edge response')
@@ -373,7 +368,7 @@ describe('Switchable runtime', () => {
           'pages/api/syntax-error-in-dev.js',
           `
         export const config = {
-          runtime: 'experimental-edge',
+          runtime: 'edge',
         }
 
         export default  => new Response('edge response')
@@ -391,7 +386,7 @@ describe('Switchable runtime', () => {
           export default () => new Response('edge response again')
 
           export const config = {
-            runtime: 'experimental-edge',
+            runtime: 'edge',
           }
 
         `

--- a/test/e2e/switchable-runtime/pages/api/edge.js
+++ b/test/e2e/switchable-runtime/pages/api/edge.js
@@ -3,5 +3,5 @@ export default (req) => {
 }
 
 export const config = {
-  runtime: `experimental-edge`,
+  runtime: `edge`,
 }

--- a/test/e2e/switchable-runtime/pages/api/hello.js
+++ b/test/e2e/switchable-runtime/pages/api/hello.js
@@ -3,5 +3,5 @@ export default (req) => {
 }
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }

--- a/test/e2e/switchable-runtime/pages/api/syntax-error-in-dev.js
+++ b/test/e2e/switchable-runtime/pages/api/syntax-error-in-dev.js
@@ -1,5 +1,5 @@
 export default () => new Response('edge response')
 
 export const config = {
-  runtime: `experimental-edge`,
+  runtime: `edge`,
 }

--- a/test/integration/edge-runtime-configurable-guards/pages/api/route.js
+++ b/test/integration/edge-runtime-configurable-guards/pages/api/route.js
@@ -4,5 +4,5 @@ export default () => {
 }
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }

--- a/test/integration/edge-runtime-configurable-guards/test/index.test.js
+++ b/test/integration/edge-runtime-configurable-guards/test/index.test.js
@@ -72,7 +72,7 @@ describe('Edge runtime configurable guards', () => {
           return Response.json({ result: true })
         }
         export const config = {
-          runtime: 'experimental-edge',
+          runtime: 'edge',
           unstable_allowDynamic: '/lib/**'
         }
       `)
@@ -125,7 +125,7 @@ describe('Edge runtime configurable guards', () => {
             return Response.json({ result: true })
           }
           export const config = {
-            runtime: 'experimental-edge',
+            runtime: 'edge',
             unstable_allowDynamic: '**'
           }
         `)
@@ -159,7 +159,7 @@ describe('Edge runtime configurable guards', () => {
             return Response.json({ result: true })
           }
           export const config = {
-            runtime: 'experimental-edge',
+            runtime: 'edge',
             unstable_allowDynamic: '/lib/**'
           }
         `)
@@ -221,7 +221,7 @@ describe('Edge runtime configurable guards', () => {
             return Response.json({ result: true })
           }
           export const config = {
-            runtime: 'experimental-edge',
+            runtime: 'edge',
             unstable_allowDynamic: '**'
           }
         `)
@@ -257,7 +257,7 @@ describe('Edge runtime configurable guards', () => {
             return Response.json({ result: true })
           }
           export const config = {
-            runtime: 'experimental-edge',
+            runtime: 'edge',
             unstable_allowDynamic: '/lib/**'
           }
         `)
@@ -328,7 +328,7 @@ describe('Edge runtime configurable guards', () => {
             return Response.json({ result: true })
           }
           export const config = {
-            runtime: 'experimental-edge',
+            runtime: 'edge',
             unstable_allowDynamic: '/pages/**'
           }
         `)
@@ -397,7 +397,7 @@ describe('Edge runtime configurable guards', () => {
           export default async function handler(request) {
             return Response.json({ result: (() => {}) instanceof Function })
           }
-          export const config = { runtime: 'experimental-edge' }
+          export const config = { runtime: 'edge' }
         `)
       },
     },

--- a/test/integration/edge-runtime-dynamic-code/pages/api/route.js
+++ b/test/integration/edge-runtime-dynamic-code/pages/api/route.js
@@ -23,4 +23,4 @@ export default async function handler(request) {
   )
 }
 
-export const config = { runtime: 'experimental-edge' }
+export const config = { runtime: 'edge' }

--- a/test/integration/edge-runtime-module-errors/pages/api/route.js
+++ b/test/integration/edge-runtime-module-errors/pages/api/route.js
@@ -2,4 +2,4 @@ export default async function handler(request) {
   return Response.json({ ok: true })
 }
 
-export const config = { runtime: 'experimental-edge' }
+export const config = { runtime: 'edge' }

--- a/test/integration/edge-runtime-module-errors/test/index.test.js
+++ b/test/integration/edge-runtime-module-errors/test/index.test.js
@@ -68,7 +68,7 @@ describe('Edge runtime code with imports', () => {
             return Response.json({ ok: basename() })
           }
 
-          export const config = { runtime: 'experimental-edge' }
+          export const config = { runtime: 'edge' }
         `)
       },
     },
@@ -129,7 +129,7 @@ describe('Edge runtime code with imports', () => {
             return Response.json({ ok: writeFile() })
           }
   
-          export const config = { runtime: 'experimental-edge' }
+          export const config = { runtime: 'edge' }
         `)
       },
     },
@@ -188,7 +188,7 @@ describe('Edge runtime code with imports', () => {
             return Response.json({ ok: await throwAsync() })
           }
   
-          export const config = { runtime: 'experimental-edge' }
+          export const config = { runtime: 'edge' }
         `)
       },
     },
@@ -267,7 +267,7 @@ describe('Edge runtime code with imports', () => {
             return Response.json({ ok: true })
           }
   
-          export const config = { runtime: 'experimental-edge' }
+          export const config = { runtime: 'edge' }
         `)
       },
     },
@@ -325,7 +325,7 @@ describe('Edge runtime code with imports', () => {
             return Response.json({ ok: true })
           }
   
-          export const config = { runtime: 'experimental-edge' }
+          export const config = { runtime: 'edge' }
         `)
       },
     },
@@ -384,7 +384,7 @@ describe('Edge runtime code with imports', () => {
             return Response.json({ ok: true })
           }
   
-          export const config = { runtime: 'experimental-edge' }
+          export const config = { runtime: 'edge' }
         `)
       },
     },
@@ -445,7 +445,7 @@ describe('Edge runtime code with imports', () => {
             return Response.json({ ok: true })
           }
   
-          export const config = { runtime: 'experimental-edge' }
+          export const config = { runtime: 'edge' }
         `)
       },
     },
@@ -503,7 +503,7 @@ describe('Edge runtime code with imports', () => {
             return response
           }
   
-          export const config = { runtime: 'experimental-edge' }
+          export const config = { runtime: 'edge' }
         `)
       },
     },
@@ -564,7 +564,7 @@ describe('Edge runtime code with imports', () => {
             return response
           }
   
-          export const config = { runtime: 'experimental-edge' }
+          export const config = { runtime: 'edge' }
         `)
       },
     },

--- a/test/integration/edge-runtime-response-error/pages/api/route.js
+++ b/test/integration/edge-runtime-response-error/pages/api/route.js
@@ -2,4 +2,4 @@ export default async function handler(request) {
   return 'Boom'
 }
 
-export const config = { runtime: 'experimental-edge' }
+export const config = { runtime: 'edge' }

--- a/test/integration/edge-runtime-streaming-error/pages/api/test.js
+++ b/test/integration/edge-runtime-streaming-error/pages/api/test.js
@@ -1,6 +1,7 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
+
 export default function () {
   return new Response(
     new ReadableStream({

--- a/test/integration/edge-runtime-with-node.js-apis/pages/api/route.js
+++ b/test/integration/edge-runtime-with-node.js-apis/pages/api/route.js
@@ -5,4 +5,4 @@ export default async function handler(request) {
   return Response.json({ ok: true })
 }
 
-export const config = { runtime: 'experimental-edge' }
+export const config = { runtime: 'edge' }

--- a/test/integration/image-generation/app/pages/api/image.jsx
+++ b/test/integration/image-generation/app/pages/api/image.jsx
@@ -5,5 +5,5 @@ export default async () => {
 }
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }

--- a/test/integration/telemetry/pages/api/og.jsx
+++ b/test/integration/telemetry/pages/api/og.jsx
@@ -5,5 +5,5 @@ export default async () => {
 }
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }

--- a/test/production/generate-middleware-source-maps/index.test.ts
+++ b/test/production/generate-middleware-source-maps/index.test.ts
@@ -13,7 +13,7 @@ describe('Middleware source maps', () => {
           export default function () { return <div>Hello, world!</div> }
         `,
         'pages/api/edge.js': `
-          export const config = { runtime: 'experimental-edge' };
+          export const config = { runtime: 'edge' };
           export default function (req) {
             return new Response("Hello from " + req.url);
           }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
